### PR TITLE
implement client logout

### DIFF
--- a/pkg/auth/authhttpservice.go
+++ b/pkg/auth/authhttpservice.go
@@ -163,14 +163,18 @@ func (ahs *AuthHTTPService) RefreshRoute() pz.Route {
 						},
 					)
 				}
-				return pz.InternalServerError(&logging{
-					Message:   "refreshing access token",
-					ErrorType: fmt.Sprintf("%T", err),
-					Error:     err.Error(),
-				})
+				return pz.HandleError(
+					"refreshing access token",
+					err,
+					&logging{
+						Message:   "refreshing access token",
+						ErrorType: fmt.Sprintf("%T", err),
+						Error:     err.Error(),
+					},
+				)
 			}
 
-			return pz.Ok(pz.JSON(&refresh{accessToken}))
+			return pz.Ok(pz.JSON(&RefreshResponse{accessToken}))
 		},
 	}
 }
@@ -359,6 +363,6 @@ type logging struct {
 	Error     string       `json:"error,omitempty"`
 }
 
-type refresh struct {
+type RefreshResponse struct {
 	AccessToken string `json:"accessToken"`
 }

--- a/pkg/client/auth.go
+++ b/pkg/client/auth.go
@@ -104,7 +104,7 @@ func (atws *AuthTypeWebServer) validate(
 		if err, ok := err.(*jwt.ValidationError); ok {
 			masked := err.Errors & jwt.ValidationErrorExpired
 			if masked == jwt.ValidationErrorExpired {
-				tokens, err := atws.Client.Refresh(refreshToken)
+				rsp, err := atws.Client.Refresh(refreshToken)
 				if err != nil {
 					return resultErr("refreshing access token", err)
 				}
@@ -113,12 +113,12 @@ func (atws *AuthTypeWebServer) validate(
 				// it's coming directly from the auth service, but we need its
 				// user. If we got here, the previous access token's user
 				// failed to parse because the token was expired.
-				user, err := validateAccessToken(tokens.AccessToken.Token, key)
+				user, err := validateAccessToken(rsp.AccessToken, key)
 				if err != nil {
 					return resultErr("parsing `sub` (user) claim", err)
 				}
 
-				encrypted, err := atws.Encrypt(tokens.AccessToken.Token)
+				encrypted, err := atws.Encrypt(rsp.AccessToken)
 				if err != nil {
 					return resultErr("encrypting access token", err)
 				}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -13,78 +13,79 @@ import (
 	"github.com/dgrijalva/jwt-go"
 	"github.com/weberc2/auth/pkg/auth"
 	"github.com/weberc2/auth/pkg/testsupport"
+	"github.com/weberc2/auth/pkg/types"
 	pz "github.com/weberc2/httpeasy"
 	pztest "github.com/weberc2/httpeasy/testsupport"
+	"golang.org/x/crypto/bcrypt"
 )
 
-func testClient(srv *httptest.Server) Client {
-	httpClient := srv.Client()
-	httpClient.CheckRedirect = func(*http.Request, []*http.Request) error {
-		return http.ErrUseLastResponse
+func TestClient_Logout(t *testing.T) {
+	jwt.TimeFunc = func() time.Time { return now }
+	defer func() { jwt.TimeFunc = time.Now }()
+	users := testsupport.UserStoreFake{
+		"user": &types.UserEntry{
+			User:  "user",
+			Email: "user@example.org",
+			PasswordHash: func() []byte {
+				hash, err := bcrypt.GenerateFromPassword(
+					[]byte("password"),
+					bcrypt.DefaultCost,
+				)
+				if err != nil {
+					t.Fatalf("unexpected error bcrypt-hashing password: %v", err)
+				}
+				return hash
+			}(),
+		},
 	}
-	return Client{HTTP: *httpClient, BaseURL: srv.URL}
+	authService, err := testAuthService(users)
+	if err != nil {
+		t.Fatalf("creating test `auth.AuthService`: %v", err)
+	}
+	tokens, err := authService.Login(&types.Credentials{
+		User:     "user",
+		Email:    "user@example.org",
+		Password: "password",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error logging in: %v", err)
+	}
+
+	api := auth.AuthHTTPService{AuthService: authService}
+	srv := httptest.NewServer(pz.Register(
+		pztest.TestLog(t),
+		api.RefreshRoute(),
+		api.LogoutRoute(),
+	))
+	defer srv.Close()
+
+	t.Logf("URL: %s", srv.URL)
+
+	client := testClient(srv)
+
+	// make sure we can refresh
+	_, err = client.Refresh(tokens.RefreshToken.Token)
+	if err != nil {
+		t.Fatalf("unexpected error refreshing token: %v", err)
+	}
+
+	// logout; make sure there's no error
+	if err := client.Logout(tokens.RefreshToken.Token); err != nil {
+		t.Fatalf("logout error: expected `nil`; found `%v`", err)
+	}
+
+	// make sure we CANNOT refresh
+	_, err = client.Refresh(tokens.RefreshToken.Token)
+	if err := auth.ErrUnauthorized.CompareErr(err); err != nil {
+		t.Fatal(err)
+	}
 }
 
-func testAuthService(now time.Time) (auth.AuthService, error) {
-	authCodeKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
-	if err != nil {
-		return auth.AuthService{}, fmt.Errorf(
-			"unexpected error generating auth code key: %w",
-			err,
-		)
-	}
-	accessKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
-	if err != nil {
-		return auth.AuthService{}, fmt.Errorf(
-			"unexpected error generating access key: %w",
-			err,
-		)
-	}
-	refreshKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
-	if err != nil {
-		return auth.AuthService{}, fmt.Errorf(
-			"unexpected error generating refresh key: %w",
-			err,
-		)
-	}
-
-	codes := auth.TokenFactory{
-		Issuer:        "issuer",
-		Audience:      "audience",
-		TokenValidity: time.Minute,
-		SigningKey:    authCodeKey,
-	}
-
-	return auth.AuthService{
-		Creds: auth.CredStore{
-			Users: testsupport.UserStoreFake{},
-		},
-		Notifications: testsupport.NotificationServiceFake{},
-		Codes:         codes,
-		TokenDetails: auth.TokenDetailsFactory{
-			AccessTokens: auth.TokenFactory{
-				Issuer:        "issuer",
-				Audience:      "audience",
-				TokenValidity: 15 * time.Minute,
-				SigningKey:    accessKey,
-			},
-			RefreshTokens: auth.TokenFactory{
-				Issuer:        "issuer",
-				Audience:      "audience",
-				TokenValidity: 15 * time.Minute,
-				SigningKey:    refreshKey,
-			},
-			TimeFunc: func() time.Time { return now },
-		},
-	}, nil
-}
-
-func TestExchangeRoute(t *testing.T) {
-	now := time.Date(1988, 8, 3, 0, 0, 0, 0, time.UTC)
+func TestClient_Exchange(t *testing.T) {
 	jwt.TimeFunc = func() time.Time { return now }
 	defer func() { jwt.TimeFunc = time.Now }()
 
-	authService, err := testAuthService(now)
+	authService, err := testAuthService(nil)
 	if err != nil {
 		t.Fatalf("creating test `auth.AuthService`: %v", err)
 	}
@@ -118,3 +119,76 @@ func TestExchangeRoute(t *testing.T) {
 		t.Fatal("missing refresh token")
 	}
 }
+
+func testClient(srv *httptest.Server) Client {
+	httpClient := srv.Client()
+	httpClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	return Client{HTTP: *httpClient, BaseURL: srv.URL}
+}
+
+func testAuthService(
+	users testsupport.UserStoreFake,
+) (auth.AuthService, error) {
+	authCodeKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	if err != nil {
+		return auth.AuthService{}, fmt.Errorf(
+			"unexpected error generating auth code key: %w",
+			err,
+		)
+	}
+	accessKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	if err != nil {
+		return auth.AuthService{}, fmt.Errorf(
+			"unexpected error generating access key: %w",
+			err,
+		)
+	}
+	refreshKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	if err != nil {
+		return auth.AuthService{}, fmt.Errorf(
+			"unexpected error generating refresh key: %w",
+			err,
+		)
+	}
+
+	codes := auth.TokenFactory{
+		Issuer:        "issuer",
+		Audience:      "audience",
+		TokenValidity: time.Minute,
+		SigningKey:    authCodeKey,
+	}
+
+	if users == nil {
+		users = testsupport.UserStoreFake{}
+	}
+
+	return auth.AuthService{
+		Tokens:        testsupport.TokenStoreFake{},
+		Creds:         auth.CredStore{Users: users},
+		Notifications: testsupport.NotificationServiceFake{},
+		Codes:         codes,
+		TokenDetails: auth.TokenDetailsFactory{
+			AccessTokens: auth.TokenFactory{
+				Issuer:        "issuer",
+				Audience:      "audience",
+				TokenValidity: 15 * time.Minute,
+				SigningKey:    accessKey,
+			},
+			RefreshTokens: auth.TokenFactory{
+				Issuer:        "issuer",
+				Audience:      "audience",
+				TokenValidity: 15 * time.Minute,
+				SigningKey:    refreshKey,
+			},
+			TimeFunc: func() time.Time { return now },
+		},
+	}, nil
+}
+
+func nowFunc() time.Time { return now }
+
+var (
+	now = time.Date(1988, 8, 3, 0, 0, 0, 0, time.UTC)
+)

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -187,8 +187,6 @@ func testAuthService(
 	}, nil
 }
 
-func nowFunc() time.Time { return now }
-
 var (
 	now = time.Date(1988, 8, 3, 0, 0, 0, 0, time.UTC)
 )

--- a/pkg/client/webserverapp_test.go
+++ b/pkg/client/webserverapp_test.go
@@ -19,7 +19,7 @@ func TestAuthCodeCallback(t *testing.T) {
 	jwt.TimeFunc = func() time.Time { return now }
 	defer func() { jwt.TimeFunc = time.Now }()
 
-	authService, err := testAuthService(now)
+	authService, err := testAuthService(nil)
 	if err != nil {
 		t.Fatalf("creating test `auth.AuthService`: %v", err)
 	}

--- a/pkg/types/tokenstore.go
+++ b/pkg/types/tokenstore.go
@@ -10,8 +10,8 @@ import (
 
 var (
 	ErrTokenNotFound = &pz.HTTPError{
-		Status:  http.StatusNotFound,
-		Message: "token not found",
+		Status:  http.StatusUnauthorized,
+		Message: "unauthorized",
 	}
 	ErrTokenExists = &pz.HTTPError{
 		Status:  http.StatusConflict,


### PR DESCRIPTION
* pkg/auth: `AuthHTTPService.RefreshRoute()` handle `types.ErrTokenNotFound`
* pkg/auth: fix `AuthHTTPService` tests
* pkg/client: implement `Client.Logout()`
* pkg/client: fix `Client.Refresh()`
* pkg/types: `types.ErrTokenNotFound` now returns `http.StatusUnauthorized`