### PR TITLE
Implement logout helper route for client webserver apps

### DIFF
--- a/cmd/auth/config.go
+++ b/cmd/auth/config.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ses"
 	"github.com/kelseyhightower/envconfig"
 	"github.com/weberc2/auth/pkg/auth"
+	"github.com/weberc2/auth/pkg/pgtokenstore"
 	pz "github.com/weberc2/httpeasy"
 	"gopkg.in/yaml.v2"
 )
@@ -127,8 +128,13 @@ func (c *Config) Run() error {
 	if err != nil {
 		return fmt.Errorf("creating AWS session: %w", err)
 	}
+	tokenStore, err := pgtokenstore.OpenEnv()
+	if err != nil {
+		return fmt.Errorf("opening token store database connection: %w", err)
+	}
 	authService := auth.AuthHTTPService{
 		AuthService: auth.AuthService{
+			Tokens: tokenStore,
 			Creds: auth.CredStore{Users: &auth.DynamoDBUserStore{
 				Client: dynamodb.New(sess),
 				Table:  "Users",

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -136,6 +136,9 @@ func testAuthService(options *authServiceOptions) (auth.AuthService, error) {
 		if options.authCodeFactory == nil {
 			options.authCodeFactory = defaultAuthCodeFactory()
 		}
+		if options.tokenStore == nil {
+			options.tokenStore = testsupport.TokenStoreFake{}
+		}
 	}
 	accessKey, err := p521Key()
 	if err != nil {
@@ -153,7 +156,7 @@ func testAuthService(options *authServiceOptions) (auth.AuthService, error) {
 	}
 
 	return auth.AuthService{
-		Tokens:        testsupport.TokenStoreFake{},
+		Tokens:        options.tokenStore,
 		Creds:         auth.CredStore{Users: options.userStore},
 		Notifications: testsupport.NotificationServiceFake{},
 		Codes:         *options.authCodeFactory,
@@ -178,6 +181,7 @@ func testAuthService(options *authServiceOptions) (auth.AuthService, error) {
 type authServiceOptions struct {
 	userStore       testsupport.UserStoreFake
 	authCodeFactory *auth.TokenFactory
+	tokenStore      testsupport.TokenStoreFake
 }
 
 func defaultAuthCodeFactory() *auth.TokenFactory {
@@ -193,6 +197,7 @@ func defaultAuthServiceOptions() *authServiceOptions {
 	return &authServiceOptions{
 		userStore:       testsupport.UserStoreFake{},
 		authCodeFactory: defaultAuthCodeFactory(),
+		tokenStore:      testsupport.TokenStoreFake{},
 	}
 }
 

--- a/pkg/client/webserverapp.go
+++ b/pkg/client/webserverapp.go
@@ -69,9 +69,7 @@ func (app *WebServerApp) LogoutRoute(path string) pz.Route {
 				Error              string `json:"error,omitempty"`
 			}
 
-			context := logging{
-				RedirectSpecified: r.URL.Query().Get("redirect"),
-			}
+			context := logging{RedirectSpecified: r.Headers.Get("Referer")}
 
 			if err := validateURL(context.RedirectSpecified); err != nil {
 				context.RedirectParseError = err.Error()

--- a/pkg/client/webserverapp.go
+++ b/pkg/client/webserverapp.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	pz "github.com/weberc2/httpeasy"
 )
@@ -54,6 +55,57 @@ func (app *WebServerApp) Encrypt(data string) (string, error) {
 	return encrypt(data, app.Key)
 }
 
+func (app *WebServerApp) LogoutRoute(path string) pz.Route {
+	return pz.Route{
+		Path:   path,
+		Method: "GET",
+		Handler: func(r pz.Request) pz.Response {
+			type logging struct {
+				Message            string `json:"message"`
+				Redirect           string `json:"redirect"`
+				RedirectSpecified  string `json:"redirectSpecified"`
+				RedirectParseError string `json:"redirectParseError,omitempty"`
+				Error              string `json:"error,omitempty"`
+			}
+
+			context := logging{
+				RedirectSpecified: r.URL.Query().Get("redirect"),
+			}
+
+			if err := validateURL(context.RedirectSpecified); err != nil {
+				context.RedirectParseError = err.Error()
+				context.Redirect = join(app.BaseURL, app.DefaultRedirect)
+			} else {
+				context.Redirect = join(app.BaseURL, context.RedirectSpecified)
+			}
+
+			refreshCookie, err := r.Cookie("Refresh-Token")
+			if err != nil {
+				context.Message = "missing refresh token cookie; nothing to " +
+					"do; redirecting"
+				context.Error = err.Error()
+				return pz.SeeOther(context.Redirect, &context)
+			}
+			if err := app.Client.Logout(refreshCookie.Value); err != nil {
+				context.Message = "issuing logout request to auth server"
+				context.Error = err.Error()
+				return pz.InternalServerError(&context)
+			}
+
+			portStart := strings.Index(app.BaseURL.Host, ":")
+			if portStart < 0 {
+				portStart = len(app.BaseURL.Host)
+			}
+			cookieDomain := app.BaseURL.Host[:portStart]
+			context.Message = "successfully logged out"
+			return pz.SeeOther(context.Redirect, &context).WithCookies(
+				cookie("Access-Token", cookieDomain, ""),
+				cookie("Refresh-Token", cookieDomain, ""),
+			)
+		},
+	}
+}
+
 func (app *WebServerApp) AuthCodeCallbackRoute(path string) pz.Route {
 	return pz.Route{
 		Path:   path,
@@ -93,4 +145,12 @@ func decrypt(input, key string) (string, error) {
 	nsz := gcm.NonceSize()
 	data, err := gcm.Open(nil, encrypted[:nsz], encrypted[nsz:], nil)
 	return string(data), err
+}
+
+func validateURL(input string) error {
+	if input == "" {
+		return fmt.Errorf("url is empty")
+	}
+	_, err := url.Parse(input)
+	return err
 }

--- a/pkg/client/webserverapp.go
+++ b/pkg/client/webserverapp.go
@@ -75,7 +75,7 @@ func (app *WebServerApp) LogoutRoute(path string) pz.Route {
 				context.RedirectParseError = err.Error()
 				context.Redirect = join(app.BaseURL, app.DefaultRedirect)
 			} else {
-				context.Redirect = join(app.BaseURL, context.RedirectSpecified)
+				context.Redirect = context.RedirectSpecified
 			}
 
 			refreshCookie, err := r.Cookie("Refresh-Token")

--- a/pkg/client/webserverapp_test.go
+++ b/pkg/client/webserverapp_test.go
@@ -5,17 +5,183 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/dgrijalva/jwt-go"
 	"github.com/weberc2/auth/pkg/auth"
+	"github.com/weberc2/auth/pkg/testsupport"
 	"github.com/weberc2/auth/pkg/types"
 	pz "github.com/weberc2/httpeasy"
 	pztest "github.com/weberc2/httpeasy/testsupport"
 )
 
-func TestAuthCodeCallback(t *testing.T) {
+func TestWebServerApp_Logout(t *testing.T) {
+	for _, testCase := range []struct {
+		name            string
+		tokenStore      testsupport.TokenStoreFake
+		redirectDefault string
+		params          map[string]string
+		cookies         map[string]string
+		wantedStatus    int
+		wantedLocation  string
+		wantedTokens    bool
+	}{
+		{
+			name:            "simple",
+			tokenStore:      testsupport.TokenStoreFake{"refresh-token": now},
+			redirectDefault: "default",
+			params:          map[string]string{},
+			cookies: map[string]string{
+				"Refresh-Token": "refresh-token",
+			},
+			wantedStatus:   http.StatusSeeOther,
+			wantedLocation: "default",
+			wantedTokens:   false,
+		},
+		{
+			// If there's no token cookie, then there's nothing to do, so just
+			// redirect.
+			name:            "token cookie not found",
+			tokenStore:      testsupport.TokenStoreFake{},
+			redirectDefault: "default",
+			params:          map[string]string{},
+			cookies:         map[string]string{},
+			wantedStatus:    http.StatusSeeOther,
+			wantedLocation:  "default",
+			wantedTokens:    false,
+		},
+		{
+			// If the provided token isn't found in the token store, then
+			// there's nothing to do, so unset the token cookie and redirect.
+			name:            "token not found",
+			tokenStore:      testsupport.TokenStoreFake{},
+			redirectDefault: "default",
+			params:          map[string]string{},
+			cookies: map[string]string{
+				"Refresh-Token": "refresh-token",
+			},
+			wantedStatus:   http.StatusSeeOther,
+			wantedLocation: "default",
+			wantedTokens:   false,
+		},
+		{
+			name:            "redirect",
+			tokenStore:      testsupport.TokenStoreFake{"redirect-token": now},
+			redirectDefault: "default",
+			params:          map[string]string{"redirect": "redirect"},
+			cookies: map[string]string{
+				"Refresh-Token": "refresh-token",
+			},
+			wantedStatus:   http.StatusSeeOther,
+			wantedLocation: "redirect",
+			wantedTokens:   false,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			app := WebServerApp{
+				Client: testClient(testAuthServer(
+					t,
+					&authServiceOptions{
+						tokenStore: testCase.tokenStore,
+					},
+				)),
+				DefaultRedirect: testCase.redirectDefault,
+				Key:             "cookie-encryption-key",
+			}
+			var (
+				err    error
+				appSrv = testServer(t, app.LogoutRoute("/auth/logout"))
+			)
+			app.BaseURL, err = url.Parse(appSrv.URL)
+			if err != nil {
+				t.Fatalf("unexpected error parsing webserver app url: %v", err)
+			}
+			appClient := testHTTPClient(appSrv)
+
+			values := url.Values{}
+			for key, value := range testCase.params {
+				values.Add(key, value)
+			}
+
+			url := fmt.Sprintf(
+				"%s/auth/logout?%s",
+				appSrv.URL,
+				values.Encode(),
+			)
+			t.Logf("GET %s", url)
+
+			req, err := http.NewRequest("GET", url, strings.NewReader(""))
+			if err != nil {
+				t.Fatalf("unexpected error building request: %v", err)
+			}
+
+			cookieDomain := join(app.BaseURL, "auth/logout")
+			for cookieName, cookieValue := range testCase.cookies {
+				req.AddCookie(cookie(cookieName, cookieDomain, cookieValue))
+			}
+
+			rsp, err := appClient.Do(req)
+			if err != nil {
+				t.Fatalf(
+					"unexpected error communicating with app server: %v",
+					err,
+				)
+			}
+
+			if rsp.StatusCode != testCase.wantedStatus {
+				t.Fatalf(
+					"Response.StatusCode: wanted `%d`; found `%d`",
+					testCase.wantedStatus,
+					rsp.StatusCode,
+				)
+			}
+
+			var wanted string
+			if testCase.wantedLocation != "" {
+				wanted = fmt.Sprintf(
+					"%s/%s",
+					appSrv.URL,
+					testCase.wantedLocation,
+				)
+			}
+			found := rsp.Header.Get("Location")
+			if wanted != found {
+				t.Fatalf(
+					"Response.Header[\"Location\"]: wanted `%s`; found `%s`",
+					wanted,
+					found,
+				)
+			}
+
+			cookies := rsp.Cookies()
+			var accessToken, refreshToken string
+			for _, cookie := range cookies {
+				if cookie.Name == "Access-Token" {
+					accessToken = cookie.Value
+				} else if cookie.Name == "Refresh-Token" {
+					refreshToken = cookie.Value
+				}
+			}
+
+			if testCase.wantedTokens &&
+				(accessToken == "" || refreshToken == "") {
+				t.Logf("Access-Token: %s", accessToken)
+				t.Logf("Refresh-Token: %s", refreshToken)
+				t.Fatal("wanted tokens, but at least one is empty")
+			}
+			if !testCase.wantedTokens &&
+				(accessToken != "" || refreshToken != "") {
+				t.Logf("Access-Token: %s", accessToken)
+				t.Logf("Refresh-Token: %s", refreshToken)
+				t.Fatal("didn't want tokens, but at least one is set")
+			}
+		})
+	}
+}
+
+func TestWebServerApp_AuthCodeCallback(t *testing.T) {
 	var (
 		now             = time.Date(2000, 9, 15, 0, 0, 0, 0, time.UTC)
 		issuer          = "issuer"
@@ -88,95 +254,118 @@ func TestAuthCodeCallback(t *testing.T) {
 			wantedLocation:  "",
 		},
 	} {
-		app := WebServerApp{
-			Client:          testClient(testAuthServer(t, &authCodeFactory)),
-			DefaultRedirect: testCase.redirectDefault,
-			Key:             "cookie-encryption-key",
-		}
-
-		var (
-			err    error
-			appSrv = testServer(t, app.AuthCodeCallbackRoute("/api/auth/code"))
-		)
-		app.BaseURL, err = url.Parse(appSrv.URL)
-		if err != nil {
-			t.Fatalf("unexpected error parsing webserver app url: %v", err)
-		}
-
-		appClient := testHTTPClient(appSrv)
-
-		values := url.Values{}
-		for key, value := range testCase.params {
-			values.Add(key, value)
-		}
-
-		url := fmt.Sprintf("%s/api/auth/code?%s", appSrv.URL, values.Encode())
-		t.Logf("GET %s", url)
-
-		rsp, err := appClient.Get(url)
-		if err != nil {
-			t.Fatalf("unexpected error communicating with app server: %v", err)
-		}
-
-		if rsp.StatusCode != testCase.wantedStatus {
-			t.Fatalf(
-				"Response.StatusCode: wanted `%d`; found `%d`",
-				testCase.wantedStatus,
-				rsp.StatusCode,
-			)
-		}
-
-		var wanted string
-		if testCase.wantedLocation != "" {
-			wanted = fmt.Sprintf("%s/%s", appSrv.URL, testCase.wantedLocation)
-		}
-		found := rsp.Header.Get("Location")
-		if wanted != found {
-			t.Fatalf(
-				"Response.Header[\"Location\"]: wanted `%s`; found `%s`",
-				wanted,
-				found,
-			)
-		}
-
-		cookies := rsp.Cookies()
-		var accessToken, refreshToken string
-		for _, cookie := range cookies {
-			if cookie.Name == "Access-Token" {
-				accessToken = cookie.Value
-			} else if cookie.Name == "Refresh-Token" {
-				refreshToken = cookie.Value
+		t.Run(testCase.name, func(t *testing.T) {
+			app := WebServerApp{
+				Client: testClient(testAuthServer(
+					t,
+					&authServiceOptions{
+						authCodeFactory: &authCodeFactory,
+					},
+				)),
+				DefaultRedirect: testCase.redirectDefault,
+				Key:             "cookie-encryption-key",
 			}
-		}
 
-		if testCase.wantedTokens && (accessToken == "" || refreshToken == "") {
-			t.Logf("Access-Token: %s", accessToken)
-			t.Logf("Refresh-Token: %s", refreshToken)
-			t.Fatal("wanted tokens, but at least one is empty")
-		}
-		if !testCase.wantedTokens &&
-			(accessToken != "" || refreshToken != "") {
-			t.Logf("Access-Token: %s", accessToken)
-			t.Logf("Refresh-Token: %s", refreshToken)
-			t.Fatal("didn't want tokens, but at least one is set")
-		}
+			var (
+				err    error
+				appSrv = testServer(
+					t,
+					app.AuthCodeCallbackRoute("/api/auth/code"),
+				)
+			)
+			app.BaseURL, err = url.Parse(appSrv.URL)
+			if err != nil {
+				t.Fatalf("unexpected error parsing webserver app url: %v", err)
+			}
+
+			appClient := testHTTPClient(appSrv)
+
+			values := url.Values{}
+			for key, value := range testCase.params {
+				values.Add(key, value)
+			}
+
+			url := fmt.Sprintf(
+				"%s/api/auth/code?%s",
+				appSrv.URL,
+				values.Encode(),
+			)
+			t.Logf("GET %s", url)
+
+			rsp, err := appClient.Get(url)
+			if err != nil {
+				t.Fatalf(
+					"unexpected error communicating with app server: %v",
+					err,
+				)
+			}
+
+			if rsp.StatusCode != testCase.wantedStatus {
+				t.Fatalf(
+					"Response.StatusCode: wanted `%d`; found `%d`",
+					testCase.wantedStatus,
+					rsp.StatusCode,
+				)
+			}
+
+			var wanted string
+			if testCase.wantedLocation != "" {
+				wanted = fmt.Sprintf(
+					"%s/%s",
+					appSrv.URL,
+					testCase.wantedLocation,
+				)
+			}
+			found := rsp.Header.Get("Location")
+			if wanted != found {
+				t.Fatalf(
+					"Response.Header[\"Location\"]: wanted `%s`; found `%s`",
+					wanted,
+					found,
+				)
+			}
+
+			cookies := rsp.Cookies()
+			var accessToken, refreshToken string
+			for _, cookie := range cookies {
+				if cookie.Name == "Access-Token" {
+					accessToken = cookie.Value
+				} else if cookie.Name == "Refresh-Token" {
+					refreshToken = cookie.Value
+				}
+			}
+
+			if testCase.wantedTokens &&
+				(accessToken == "" || refreshToken == "") {
+				t.Logf("Access-Token: %s", accessToken)
+				t.Logf("Refresh-Token: %s", refreshToken)
+				t.Fatal("wanted tokens, but at least one is empty")
+			}
+			if !testCase.wantedTokens &&
+				(accessToken != "" || refreshToken != "") {
+				t.Logf("Access-Token: %s", accessToken)
+				t.Logf("Refresh-Token: %s", refreshToken)
+				t.Fatal("didn't want tokens, but at least one is set")
+			}
+		})
 	}
 }
 
 func testAuthServer(
 	t *testing.T,
-	authCodeFactory *auth.TokenFactory,
+	options *authServiceOptions,
 ) *httptest.Server {
-	authService, err := testAuthService(&authServiceOptions{
-		authCodeFactory: authCodeFactory,
-	})
+	authService, err := testAuthService(options)
 	if err != nil {
 		t.Fatalf("unexpected error creating test auth service: %v", err)
 	}
 
+	authHTTPService := auth.AuthHTTPService{AuthService: authService}
+
 	return testServer(
 		t,
-		(&auth.AuthHTTPService{AuthService: authService}).ExchangeRoute(),
+		authHTTPService.ExchangeRoute(),
+		authHTTPService.LogoutRoute(),
 	)
 }
 


### PR DESCRIPTION
* cmd/auth: construct `pgtokenstore` for use by `authservice`
* pkg/client: implement `WebServerApp.LogoutRoute()`
* pkg/client: fix cookie decryption bug where empty cookie values cause a panic