### PR TITLE
pkg/client: handle 'unauthorized' response from server's code exchange endpoint

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -108,6 +108,12 @@ func (c *Client) Exchange(code string) (*auth.TokenDetails, error) {
 		return nil, fmt.Errorf("exchanging auth code: %w", err)
 	}
 	if rsp.StatusCode != http.StatusOK {
+		if rsp.StatusCode == http.StatusUnauthorized {
+			return nil, fmt.Errorf(
+				"exchanging auth code: %w",
+				auth.ErrUnauthorized,
+			)
+		}
 		return nil, fmt.Errorf(
 			"auth code exchange status: wanted `200`; found `%d`",
 			rsp.StatusCode,


### PR DESCRIPTION
* pkg/client: handle auth server response code 401 by returning `auth.ErrUnauthorized`
* pkg/client: significant refactoring of `TestClient_Exchange` to support table-driven tests
* pkg/client: refactor `TestWebServerApp_AuthCodeCallback` and add test case to validate unauthorized code handling