### PR TITLE
pkg/client: previously the AuthN decorator didn't prohibit unauthorized access

### DIFF
--- a/pkg/client/auth.go
+++ b/pkg/client/auth.go
@@ -13,20 +13,13 @@ type Authenticator struct {
 	Key *ecdsa.PublicKey
 }
 
-func (a *Authenticator) AuthN(authType AuthType, h pz.Handler) pz.Handler {
-	return func(r pz.Request) pz.Response {
-		result := authType.validate(a.Key, r)
-		r.Headers.Add("User", result.User)
-		return h(r).WithLogging(result)
-	}
-}
-
-func (a *Authenticator) AuthZ(authType AuthType, h pz.Handler) pz.Handler {
+func (a *Authenticator) Auth(authType AuthType, h pz.Handler) pz.Handler {
 	return func(r pz.Request) pz.Response {
 		result := authType.validate(a.Key, r)
 		if result.User == "" {
 			return pz.Unauthorized(nil, result)
 		}
+		r.Headers.Add("User", result.User)
 		return h(r).WithLogging(result)
 	}
 }

--- a/pkg/client/auth_test.go
+++ b/pkg/client/auth_test.go
@@ -1,0 +1,55 @@
+package client
+
+import (
+	"crypto/ecdsa"
+	"errors"
+	"net/http"
+	"testing"
+
+	pz "github.com/weberc2/httpeasy"
+)
+
+func TestAuthenticator_Auth(t *testing.T) {
+	for _, testCase := range []struct {
+		name       string
+		authType   AuthType
+		wantedUser string
+	}{
+		{
+			name: "success",
+			authType: authTypeMock(
+				func(_ *ecdsa.PublicKey, r pz.Request) *result {
+					return resultOK("success", "user")
+				},
+			),
+			wantedUser: "user",
+		},
+		{
+			name: "failure",
+			authType: authTypeMock(
+				func(_ *ecdsa.PublicKey, r pz.Request) *result {
+					return resultErr("ERR", errors.New("an error occurred"))
+				},
+			),
+			wantedUser: "",
+		},
+	} {
+		var user string
+		new(Authenticator).Auth(
+			testCase.authType,
+			func(r pz.Request) pz.Response {
+				user = r.Headers.Get("User")
+				return pz.Ok(nil, nil)
+			},
+		)(pz.Request{Headers: http.Header{}})
+		if user != testCase.wantedUser {
+			t.Fatalf("wanted user `%s`; found `%s`", testCase.wantedUser, user)
+		}
+	}
+}
+
+type authTypeMock func(key *ecdsa.PublicKey, r pz.Request) *result
+
+func (f authTypeMock) validate(key *ecdsa.PublicKey, r pz.Request) *result {
+	return f(key, r)
+}


### PR DESCRIPTION
This closes https://trello.com/c/UmWaU2F3/44-authn-decorator-doesnt-prevent-unauthorized-access.
* pkg/client: fix decorator, merge with AuthZ decorator, add tests